### PR TITLE
[feat/chatdetail/#2] 실시간 채팅 닉네임 반영 + 오늘 날짜에 해당되는 모든 메시지 반환 기능 추가

### DIFF
--- a/src/component/live/ChatScreen.js
+++ b/src/component/live/ChatScreen.js
@@ -55,15 +55,7 @@ const ChatScreen = () => {
         console.log("받은 메시지: ", message.body);
         const body = JSON.parse(message.body);
 
-        // ID를 사용하여 중복 확인
-        const existingMessage = messages.find(msg => msg.id === body.id);
-        if (!existingMessage) {
-            setMessages(prevMessages => {
-                const updatedMessages = [...prevMessages, body];
-                console.log("업데이트된 messages 상태: ", updatedMessages);
-                return updatedMessages;
-            });
-        }
+        setMessages(prevMessages => [...prevMessages, body]);
     };
 
     const sendMessage = () => {

--- a/src/component/live/ChatScreen.js
+++ b/src/component/live/ChatScreen.js
@@ -26,7 +26,7 @@ const ChatScreen = () => {
     useEffect(() => {
         if (!client) {
             const newClient = new Client({
-                brokerURL: "wss://www.plick.shop/ws", //로컬->배포주소 변경
+                brokerURL: "ws://www.plick.shop/ws", //로컬->배포주소 변경
                 debug: function (str) {
                     console.log(str);
                 },

--- a/src/component/live/css/ChatMessage.css
+++ b/src/component/live/css/ChatMessage.css
@@ -35,6 +35,7 @@
   font-size: 12px;
   font-weight: 400;
   line-height: 16px;
-  text-align: right;
+  margin-left: 250px;
+  text-align: left;
   display: block;
 }


### PR DESCRIPTION
### PR 내용
-  #2 
- 실시간 채팅 닉네임 반영 + 오늘 날짜에 해당되는 모든 메시지 반환 기능 추가

### 스크린 샷
![image](https://github.com/Plick-pop-in/poppin-fe/assets/102938120/c0cebe41-a025-4baa-88d9-09833a876591)


### 참고사항
닉네임 redux의 store에 저장된 닉네임 값 받아오게 했는데 적용이 안되는 문제 발생중 => 하림이한테 물어봐야할듯
오늘날짜 기준 모든 메시지 반환해주는 것 => 테스트 해 볼 수가 없는 이슈 .. 